### PR TITLE
Point to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+The github repo has moved. The new GitHub URL is: https://github.com/fiscalobject/ufo
+
 Bitcoin Core integration/staging tree
 =====================================
 


### PR DESCRIPTION
I believe there is an option to redirect the repo to the new repo - https://github.blog/2013-05-16-repository-redirects-are-here/